### PR TITLE
feat: add vercel config and footer

### DIFF
--- a/ui/app/components/Footer.tsx
+++ b/ui/app/components/Footer.tsx
@@ -1,0 +1,26 @@
+// File: ui/app/components/Footer.tsx
+
+export default function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="bg-gray-900 text-gray-400 text-center py-6 mt-12">
+      <p className="text-sm">&copy; {year} Botsensai. All rights reserved.</p>
+      <p className="mt-2 space-x-4">
+        <a
+          href="https://twitter.com/botsensai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-white underline"
+        >
+          Twitter
+        </a>
+        <a
+          href="mailto:contact@botsensai.com"
+          className="hover:text-white underline"
+        >
+          Contact
+        </a>
+      </p>
+    </footer>
+  );
+}

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -5,6 +5,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/react";
 import { ReactQueryProvider } from "@/lib/providers/react-query-provider";
 import { Toaster } from "sonner";
+import Footer from "./components/Footer";
 
 // Load Inter font
 const inter = Inter({
@@ -55,10 +56,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="icon" href="/favicon.ico" />
       </head>
       <body className="min-h-screen bg-gray-950 text-white font-sans antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only absolute left-0 top-0 m-4 bg-gray-800 text-white px-4 py-2 rounded z-50"
+        >
+          Skip to main content
+        </a>
         <ReactQueryProvider>
-          <main className="relative overflow-x-hidden">
+          <main id="main-content" className="relative overflow-x-hidden">
             {children}
           </main>
+          <Footer />
 
           {/* Global notifications */}
           <Toaster position="top-right" richColors theme="dark" />

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    { "src": "ui/package.json", "use": "@vercel/next" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "ui/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Vercel deployment to build the `ui` app
- add global footer with contact links and an accessible skip link

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build` *(fails: Failed to fetch Inter font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689e017a6a188329b0b763c6a0bdb677