### PR TITLE
chore: proxy api requests

### DIFF
--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -55,7 +55,7 @@ const request = async <T>({
   payload,
   timeout = DEFAULT_TIMEOUT,
   headers = {},
-  baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
+  baseUrl = process.env.NEXT_PUBLIC_API_URL || "/api",
 }: RequestOptions): Promise<ApiResponse<T>> => {
   const controller = withTimeout(timeout);
 

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,12 @@
   "builds": [
     { "src": "ui/package.json", "use": "@vercel/next" }
   ],
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://market-maker-api.vercel.app/:path*"
+    }
+  ],
   "routes": [
     { "src": "/(.*)", "dest": "ui/$1" }
   ]


### PR DESCRIPTION
## Summary
- proxy /api/* requests to the python backend via Vercel rewrites
- point client API helper to `/api` so requests go through the proxy

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ab4c08a6188329bdafcebf398cdc7d