### PR TITLE
chore: drop legacy chartjs dependency

### DIFF
--- a/ui/components/ui/PriceChart.tsx
+++ b/ui/components/ui/PriceChart.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { Line } from "react-chartjs-2";
-import { ChartData, ChartOptions } from "chart.js";
+import type { ChartData, ChartOptions } from "chart.js";
 import "chart.js/auto";
 import { get } from "@/lib/api";
 import type { PricePoint } from "@/lib/types";

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,6 @@
     "@vercel/speed-insights": "^1.2.0",
     "axios": "^1.8.4",
     "chart.js": "^4.4.8",
-    "chartjs": "^0.3.24",
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-chart-financial": "^0.2.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- remove unused `chartjs` package and rely on `chart.js`
- import chart types as TypeScript types alongside `react-chartjs-2`

## Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ab4c0688348329935823692196a664