### PR TITLE
Use relative API base URL and document env config

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -54,11 +54,13 @@ Develop a full-stack market-making bot that supports:
 
 ## 🌐 Environment Variables
 
-| Key                   | Description                             |
-| --------------------- | --------------------------------------- |
-| `NEXT_PUBLIC_API_URL` | Backend URL for REST & WebSocket access |
+| Key                   | Description                                   |
+| --------------------- | --------------------------------------------- |
+| `NEXT_PUBLIC_API_URL` | Backend URL for REST & WebSocket access       |
 
-Set these in `.env.local` and in Vercel Project → Settings → Environment Variables
+By default the UI uses a relative path (`''`) for API calls.
+Set `NEXT_PUBLIC_API_URL` in `.env.local` and in your Vercel project settings when
+the backend lives on a different domain.
 
 ---
 

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -55,7 +55,7 @@ const request = async <T>({
   payload,
   timeout = DEFAULT_TIMEOUT,
   headers = {},
-  baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
+  baseUrl = process.env.NEXT_PUBLIC_API_URL || "",
 }: RequestOptions): Promise<ApiResponse<T>> => {
   const controller = withTimeout(timeout);
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,8 @@
   ],
   "routes": [
     { "src": "/(.*)", "dest": "ui/$1" }
-  ]
+  ],
+  "env": {
+    "NEXT_PUBLIC_API_URL": "https://api.example.com"
+  }
 }


### PR DESCRIPTION
## Summary
- Default API client base URL to a relative path to support Next.js API routes out of the box
- Document `NEXT_PUBLIC_API_URL` and add placeholder in Vercel config for external API deployments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68ab4c067680832998299f110544dcc5