### PR TITLE
Configure monorepo root for Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ pnpm-debug.log*
 # TypeScript build info
 tsconfig.tsbuildinfo
 ui/tsconfig.tsbuildinfo
+ui/next

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "market-maker-monorepo",
+  "private": true,
+  "workspaces": [
+    "ui"
+  ],
+  "scripts": {
+    "dev": "npm run dev --workspace ui",
+    "build": "npm run build --workspace ui",
+    "lint": "npm run lint --workspace ui",
+    "type-check": "npm run type-check --workspace ui"
+  },
+  "engines": {
+    "node": ">=18.18.0"
+  }
+}

--- a/ui/next
+++ b/ui/next
@@ -1,8 +1,0 @@
-Unknown command: "lint"
-
-
-Did you mean one of these?
-  npm link # Symlink a package folder
-  npm run lint # run the "lint" package script
-To see a list of supported npm commands, run:
-  npm help

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- add a root package.json workspace so Vercel can install dependencies and run builds from the ui app
- delete the stray ui/next executable output and ignore recreating it
- refresh Next.js generated type references after the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d93781e62c8329a0237360aee9d1ff