### PR TITLE
feat: fetch historical prices from data feed

### DIFF
--- a/api/src/main.py
+++ b/api/src/main.py
@@ -4,11 +4,12 @@ import argparse
 import os
 import logging
 import requests
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Literal
 
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, model_validator
 
 from src.modules.datafeed.data_feed import DataFeed
@@ -148,15 +149,81 @@ def exchange_code_for_token(code: str):
     token_data = response.json()
     return {"access_token": token_data["access_token"], "expires_in": token_data["expires_in"]}
 
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config", "config.yaml")
+SECRETS_PATH = os.path.join(os.path.dirname(__file__), "config", "secrets.yaml")
+
+data_feed = DataFeed(config_path=CONFIG_PATH, secrets_path=SECRETS_PATH)
+
+
 @app.get("/historical-prices")
 def get_historical_prices():
-    """Return mock historical price data for BTC/USDT."""
-    now = datetime.utcnow()
-    prices = [
-        {"timestamp": (now - timedelta(minutes=i)).isoformat() + "Z", "price": 28800 + i * 5}
-        for i in reversed(range(30))
-    ]
-    return prices
+    """Return historical price data for the configured default market."""
+
+    try:
+        config = data_feed.config or {}
+        exchange = config.get("default_exchange")
+        symbol = config.get("default_symbol")
+        timeframe = config.get("default_timeframe")
+        limit = config.get("default_limit", 100)
+
+        if not exchange or not symbol or not timeframe:
+            raise HTTPException(
+                status_code=500,
+                detail="Default market configuration is incomplete. Please update the API configuration.",
+            )
+
+        try:
+            ohlcv = data_feed.fetch_historical_data(
+                exchange_name=exchange,
+                symbol=symbol,
+                timeframe=timeframe,
+                limit=limit,
+            )
+        except Exception as exc:
+            logger.exception("Error fetching historical data: %s", exc)
+            raise HTTPException(
+                status_code=502,
+                detail=f"Failed to fetch historical data from {exchange}: {exc}",
+            ) from exc
+
+        if not ohlcv:
+            raise HTTPException(
+                status_code=400,
+                detail="Exchange credentials are missing or invalid. Please reconnect your exchange account.",
+            )
+
+        prices = []
+        for candle in ohlcv:
+            if len(candle) < 5:
+                logger.warning("Skipping malformed OHLCV candle: %s", candle)
+                continue
+
+            timestamp_ms = candle[0]
+            close_price = candle[4]
+            timestamp_iso = datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+            prices.append({
+                "timestamp": timestamp_iso,
+                "price": close_price,
+                "symbol": symbol,
+            })
+
+        if not prices:
+            raise HTTPException(
+                status_code=502,
+                detail="No valid historical data returned by the exchange.",
+            )
+
+        return prices
+
+    except HTTPException as exc:
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        logger.exception("Unexpected error preparing historical prices: %s", exc)
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "Unexpected error fetching historical data. Please try again later."},
+        )
 
 
 @app.get("/orders")

--- a/api/src/tests/test_orders_endpoint.py
+++ b/api/src/tests/test_orders_endpoint.py
@@ -1,4 +1,8 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
 from fastapi.testclient import TestClient
+
 from src.main import app, orders
 
 client = TestClient(app)
@@ -44,3 +48,80 @@ def test_limit_order_requires_limit_price():
     payload = {"side": "buy", "amount": 1, "symbol": "BTC/USDT", "type": "limit"}
     res = client.post('/orders', json=payload)
     assert res.status_code == 422
+
+
+def test_get_historical_prices_success(monkeypatch):
+    mock_data_feed = MagicMock()
+    mock_data_feed.config = {
+        "default_exchange": "binance",
+        "default_symbol": "BTC/USDT",
+        "default_timeframe": "1h",
+        "default_limit": 50,
+    }
+
+    candle_timestamp = 1625097600000
+    close_price = 50500
+
+    mock_data_feed.fetch_historical_data.return_value = [
+        [candle_timestamp, 50000, 51000, 49000, close_price, 120],
+    ]
+
+    monkeypatch.setattr("src.main.data_feed", mock_data_feed)
+
+    response = client.get("/historical-prices")
+    assert response.status_code == 200
+
+    expected_timestamp = datetime.fromtimestamp(
+        candle_timestamp / 1000, tz=timezone.utc
+    ).isoformat().replace("+00:00", "Z")
+
+    assert response.json() == [
+        {
+            "timestamp": expected_timestamp,
+            "price": close_price,
+            "symbol": "BTC/USDT",
+        }
+    ]
+
+    mock_data_feed.fetch_historical_data.assert_called_once_with(
+        exchange_name="binance",
+        symbol="BTC/USDT",
+        timeframe="1h",
+        limit=50,
+    )
+
+
+def test_get_historical_prices_missing_credentials(monkeypatch):
+    mock_data_feed = MagicMock()
+    mock_data_feed.config = {
+        "default_exchange": "binance",
+        "default_symbol": "BTC/USDT",
+        "default_timeframe": "1h",
+        "default_limit": 100,
+    }
+    mock_data_feed.fetch_historical_data.return_value = None
+
+    monkeypatch.setattr("src.main.data_feed", mock_data_feed)
+
+    response = client.get("/historical-prices")
+
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("Exchange credentials are missing or invalid")
+
+
+def test_get_historical_prices_ccxt_error(monkeypatch):
+    mock_data_feed = MagicMock()
+    mock_data_feed.config = {
+        "default_exchange": "binance",
+        "default_symbol": "BTC/USDT",
+        "default_timeframe": "1h",
+        "default_limit": 100,
+    }
+    mock_data_feed.fetch_historical_data.side_effect = Exception("ccxt failure")
+
+    monkeypatch.setattr("src.main.data_feed", mock_data_feed)
+
+    response = client.get("/historical-prices")
+
+    assert response.status_code == 502
+    assert "ccxt failure" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- wire the historical prices endpoint to the shared DataFeed using defaults from config
- convert OHLCV candles into the simplified timestamp/price payload expected by the UI
- expand endpoint unit tests to cover success, missing credentials, and ccxt error scenarios

## Testing
- AWS_DEFAULT_REGION=us-east-1 PYTHONPATH=. pytest src/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68de47709b2c8329bf6de857a8668f33