### PR TITLE
Add websocket ticker streaming support

### DIFF
--- a/api/src/tests/test_ticker_websocket.py
+++ b/api/src/tests/test_ticker_websocket.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+
+class FakeDataFeed:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+        self.received_args = None
+
+    async def start_websocket(self, exchange_name, symbol, on_message):
+        self.started = True
+        self.received_args = (exchange_name, symbol)
+        await on_message({"exchange": exchange_name, "symbol": symbol})
+
+    async def stop_websocket(self):
+        self.stopped = True
+
+
+def test_ticker_websocket_emits_messages(monkeypatch):
+    fake_feed = FakeDataFeed()
+    monkeypatch.setattr("src.main.data_feed", fake_feed)
+
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws/ticker?exchange=testex&symbol=TESTUSD") as websocket:
+        message = websocket.receive_json()
+        assert message == {"exchange": "testex", "symbol": "TESTUSD"}
+
+    assert fake_feed.started is True
+    assert fake_feed.stopped is True
+    assert fake_feed.received_args == ("testex", "TESTUSD")


### PR DESCRIPTION
## Summary
- refactor the data feed websocket client to forward parsed messages through async callbacks
- expose a `/ws/ticker` FastAPI websocket that streams ticker updates to connected clients
- add a websocket test that stubs the data feed and verifies ticker messages are emitted

## Testing
- AWS_DEFAULT_REGION=us-east-1 PYTHONPATH=api pytest api/src/tests/test_ticker_websocket.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de476faf6c8329b8f99c32204dfa3d