### PR TITLE
Update API requirements with backend dependencies

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,10 @@
-# Add FastAPI, Uvicorn, and dependencies here
 fastapi
 uvicorn
+requests
+boto3
+ccxt
+PyYAML
+tenacity
+websockets
+pandas
+matplotlib


### PR DESCRIPTION
## Summary
- add all imported backend libraries to the API requirements file so remote builds install needed dependencies

## Testing
- `docker build -t market-maker-api api` *(fails: docker is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de476bb8908329a6d6861256f30ffe