### PR TITLE
Add Fly.io configuration for API service

### DIFF
--- a/api/fly.toml
+++ b/api/fly.toml
@@ -1,0 +1,17 @@
+app = "market-maker-ui-api"
+
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[env]
+  PORT = "8000"


### PR DESCRIPTION
## Summary
- add Fly.io fly.toml configuration for the API service using the existing Dockerfile
- configure the HTTP service to use internal port 8000, enforce HTTPS, and expose PORT via the environment

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68de476ba4248329af8468b33976b1a2